### PR TITLE
Update: The utils.initializer encapsulation method is used in distributed training.

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -78,7 +78,7 @@ def train(rank=None, args=None):
         dist.init_process_group(backend="nccl" if torch.cuda.is_available() else "gloo", rank=rank,
                                 world_size=world_size)
         # Set device ID
-        device = torch.device("cuda", rank)
+        device = device_initializer(device_id=rank)
         # There may be random errors, using this function can reduce random errors in cudnn
         # torch.backends.cudnn.deterministic = True
         # Synchronization during distributed training


### PR DESCRIPTION
[Update: The utils.initializer encapsulation method is used in distributed training.](https://github.com/chairc/Industrial-Defect-Diffusion-Model/commit/bfbf9fdd9fe879466bebad8421c48b24e670d83b)