### PR TITLE
Update: Add "Base on the 64×64 model to generate every size images".

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,13 @@ We conducted training on the following four datasets using the `DDPM` sampler wi
 
 ![model_459_ema](assets/animate_face_459_ema.jpg)
 
+#### Base on the 64×64 model to generate 160×160 (every size) images
+
+Of course, based on the 64×64 U-Net model, we generate 160×160 `NEU-DET` images in the `generate.py` file (single output, each image occupies 21GB of GPU memory). Detailed images are as follows:
+
+![model_499_ema](assets/neu160_0.jpg)![model_499_ema](assets/neu160_1.jpg)![model_499_ema](assets/neu160_2.jpg)![model_499_ema](assets/neu160_3.jpg)![model_499_ema](assets/neu160_4.jpg)![model_499_ema](assets/neu160_5.jpg)
+
+
 ### Deployment
 
 To be continued.

--- a/README_zh.md
+++ b/README_zh.md
@@ -337,6 +337,12 @@ Industrial Defect Diffusion Model
 
 ![model_459_ema](assets/animate_face_459_ema.jpg)
 
+#### 基于64×64模型生成160×160（任意大尺寸）图像
+
+当然，我们根据64×64的基础模型，在`generate.py`文件中生成160×160的`NEU-DET`图片（单张输出，每张图片占用显存21GB）。详细图片如下：
+
+![model_499_ema](assets/neu160_0.jpg)![model_499_ema](assets/neu160_1.jpg)![model_499_ema](assets/neu160_2.jpg)![model_499_ema](assets/neu160_3.jpg)![model_499_ema](assets/neu160_4.jpg)![model_499_ema](assets/neu160_5.jpg)
+
 ### 部署
 
 未完待续


### PR DESCRIPTION
[Update: Add "Base on the 64×64 model to generate every size images".](https://github.com/chairc/Industrial-Defect-Diffusion-Model/commit/c020fcb095983b7f23899228ca681fc0e9cd89fd)